### PR TITLE
Usability improvements

### DIFF
--- a/src/Ctx.ts
+++ b/src/Ctx.ts
@@ -78,6 +78,7 @@ export default class Ctx extends EventEmitter<{ everyoneReady(): void }> {
   name = new UsableField('');
   item = new UsableField('');
   parties = new UsableField<Party[]>([{ name: '', item: '', ready: false }]);
+  partySizeWarningDismissed = new UsableField(false);
   pk = new UsableField<PublicKey | undefined>(undefined);
   readyFlags = new UsableField<boolean[] | undefined>(undefined);
   protocolMsgQueue = new AsyncQueue<{ from: PublicKey, data: Uint8Array }>();

--- a/src/Invite.tsx
+++ b/src/Invite.tsx
@@ -3,10 +3,15 @@ import Ctx from './Ctx';
 import { QRCodeCanvas } from 'qrcode.react';
 import TitlePill from './TitlePill';
 
+const maxRecommendedPartySize = 5;
+
 export default function Invite() {
   const ctx = Ctx.use();
   const roomCode = ctx.roomCode.use();
   const parties = ctx.parties.use();
+  const partySizeWarningDismissed = ctx.partySizeWarningDismissed.use();
+
+  const warningNeeded = parties.length >= maxRecommendedPartySize && !partySizeWarningDismissed;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
@@ -18,14 +23,34 @@ export default function Invite() {
       <p>
         Get your friends to scan:
       </p>
-      <center>
-        <QRCodeCanvas
-          style={{ width: '100%', height: 'auto' }}
-          bgColor='transparent'
-          value={`${window.location.origin}${window.location.pathname}#${roomCode}`}
-        />
-      </center>
-      <p>
+      {warningNeeded && <>
+        <div style={{
+          width: 'var(--iaw)',
+          height: 'var(--iaw)',
+        }}>
+          <p>
+            Whoa there! Running JumboSwap with more than&nbsp;
+            {maxRecommendedPartySize} parties may perform poorly. Only
+            invite more people if you like to live dangerously.
+          </p>
+          <p>
+            <a
+              onClick={() => ctx.partySizeWarningDismissed.set(true)}
+              style={{ cursor: 'pointer' }}
+            >I like to live dangerously.</a>
+          </p>
+        </div>
+      </>}
+      {!warningNeeded && <>
+        <center>
+          <QRCodeCanvas
+            style={{ width: '100%', height: 'auto' }}
+            bgColor='transparent'
+            value={`${window.location.origin}${window.location.pathname}#${roomCode}`}
+          />
+        </center>
+      </>}
+      <p style={{ visibility: warningNeeded ? 'hidden' : 'visible' }}>
         Or <CopyToClipboard text={roomCode}>
           <button style={{ padding: '0.5rem' }}>copy</button>
         </CopyToClipboard> it and send.

--- a/src/index.css
+++ b/src/index.css
@@ -36,6 +36,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
 
   --aw: min(100vw, calc(0.6 * 100vh)); /* app width */
+  --iaw: calc(0.74 * var(--aw)); /* inner app width (padding) */
 }
 
 #root {


### PR DESCRIPTION
## What is this PR doing?

- avoid bug where parties don't receive names and items that have already been entered before they joined
  - by sending this on every ping (not ideal, but works well for now)
- add warning about running JumboSwap with >5 parties (6 actually works pretty well with a strong network, and 7 has been successfully tested, but is pretty slow)

## How can these changes be manually tested?

Run the app, check the items above.

## Does this PR resolve or contribute to any issues?

Nope.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
